### PR TITLE
Custom redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To make plugin to work properly
 * Login as administrator. In top menu select "Administration". Choose menu item Plugins. In plugins list choose "Redmine Omniauth Azure plugin". Press "Configure".
 * Fill Сlient ID & Client Secret & Tenant ID by corresponding values, obtained by Azure.
 * Put the check "Oauth authentification", to make it possible to login through Azure. Click Apply. Users can now to use apportunity to login via Azure.
+* redirect_uri is optional , if you leave empty it will use redmine_url_root but if you fill this field the value introduced will be used as parameter in the calls.
 
 Additionaly
 * Setup value Autologin in Settings on tab Authentification

--- a/app/views/settings/_azure_settings.html.erb
+++ b/app/views/settings/_azure_settings.html.erb
@@ -15,6 +15,10 @@
   <%= text_area_tag "settings[allowed_domains]", @settings['allowed_domains'], :rows => 5 %>
 </p>
 <p>
+  <label>Redirect uri</label>
+  <%= text_field_tag 'settings[redirect_uri]', @settings['redirect_uri'] %>
+</p>
+<p>
   <label>Oauth authentication:</label>
   <%= check_box_tag "settings[azure_oauth_authentication]", true, @settings['azure_oauth_authentication'] %>
 </p>

--- a/init.rb
+++ b/init.rb
@@ -13,6 +13,7 @@ Redmine::Plugin.register :redmine_omniauth_azure do
     :client_id => "",
     :client_secret => "",
     :github_oauth_autentication => false,
-    :allowed_domains => ""
+    :allowed_domains => "",
+	:redirect_uri => ""
   }, :partial => 'settings/azure_settings'
 end


### PR DESCRIPTION
Hi.

I have made some changes to allow to customize the redirect_uri used as parameter in the calls to Azure.

If you leave empty the field it continues working as is doing now, using the redmine_root_url , but in case you want to customize it's possible with this change.

Regards.