### PR TITLE
Fixed a case where an error occurred with a login name if the name wa…

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -59,7 +59,7 @@ class RedmineOauthController < AccountController
       user.lastname ||= info["name"]
       user.mail = email
       user.login = info['login']
-      user.login ||= [user.firstname, user.lastname]*"."
+      user.login ||= email
       user.random_password
       user.register
 


### PR DESCRIPTION
Hello,

If the name item in Azure Active Directory contains a multi-byte character string, user creation failed.
Changed login to email. I think it will be useful in non-English speaking regions.